### PR TITLE
Allow array of strings for custom usercolor

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Default: '/etc/profile.d/colorprompt.sh'
 #### `default_usercolor` ####
 *Sets a color for all users. Specific user colors can be overridden
 by `custom_usercolors`.*  
-Type: String or Hash  
+Type: String or Array  
 Default: undef
 
 #### `custom_usercolors` ####

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,7 +85,7 @@ class colorprompt (
   # Oof, trying to turn a formerly-duck-typed language into a formally-typed
   # language creates some fun declarations!
   Variant[Undef, String, Array[String]] $default_usercolor,
-  Variant[Undef, Hash[String, String]] $custom_usercolors,
+  Variant[Undef, Hash[String, String], Hash[String, Array[String]]] $custom_usercolors,
   Variant[Undef, String, Array[String]] $host_color,
   Optional[String] $env_name,
   Variant[Undef, String, Array[String]] $env_color,


### PR DESCRIPTION
Allows you to write a configuration like
```
class { '::colorprompt':
  # ...
  custom_usercolors => {
    'root' => ['black', 'bg_red'],
  }
}
```
There was also a minor documentation error for `default_usercolor`.