### PR TITLE
skip configuration unless running bash 

### DIFF
--- a/templates/colorprompt.erb
+++ b/templates/colorprompt.erb
@@ -4,6 +4,11 @@
 # Shell Prompt Coloring
 # This script adds colors to the user and host portions of the PS1 prompt.
 
+# If the shell isn't bash or bash-comaptible, we do not change the prompt.
+if [ -z "$BASH" ]; then
+    return
+fi
+
 # If the shell isn't interactive, we have nothing to change.
 if [[ ( "$PS1" ) && ( "$TERM" != 'dumb' ) ]]; then
 	# This is used as a container to allow us to use locals instead of having to


### PR DESCRIPTION
The `[[ ... ]]` syntax is bash internal. That could be easily rewritten using the `[ ... ]` command, but there's no point since dash does not display color prompts.

Attempts to fix https://github.com/LuaMilkshake/puppet-colorprompt/issues/3